### PR TITLE
Release 1.13

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,45 +9,6 @@
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
-<!-- Google Consent mode -->
-<script data-cookieconsent="ignore">
-	window.dataLayer = window.dataLayer || [];
-	function gtag() {
-		dataLayer.push(arguments);
-	}
-	gtag("consent", "default", {
-		ad_storage: "denied",
-		analytics_storage: "denied",
-		functionality_storage: "denied",
-		personalization_storage: "denied",
-		security_storage: "granted",
-		wait_for_update: 2000,
-	});
-	gtag("set", "ads_data_redaction", true);
-</script>
-<!-- End Google Consent mode -->
-
-<script data-cookieconsent="ignore">
-	(function (w, d, s, l, i) {
-	w[l] = w[l] || [];
-	w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-	var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
-	j.async = true;
-	j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-	f.parentNode.insertBefore(j, f);
-	})(window, document, 'script', 'dataLayer', 'GTM-WZBKMJP');
-</script>
-<!-- End Google Tag Manager -->
-
-<!-- Cookiebot -->
-<script
-	id="Cookiebot"
-	src="https://consent.cookiebot.com/uc.js"
-	data-cbid="ec5f4b04-e699-4bea-a9de-eda95d4d9fb7"
-	data-blockingmode="auto"
-	type="text/javascript"
-></script>
-<!-- End Cookiebot -->
 
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/style.css
+++ b/style.css
@@ -1071,21 +1071,3 @@ object {
 .nlposts-block-thumbnail-litem-override {
     list-style: none;
 }
-
-/*--------------------------------------------------------------
-14.0 Cookiebot
---------------------------------------------------------------*/
-/*Make element 16-9 ratio*/
-.video-container {
-	position: relative;
-	padding-bottom: 56.25%;
-}
-/*Force iframe to take up as much space as the parent*/
-.video-container iframe {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-}
-


### PR DESCRIPTION
We have replaced the Cookiebot scripts and CSS in the theme. Instead, we’re now utilizing the bm-cookiebot-wordpress-plugin to handle this.

This streamlines maintenance and updates by allowing us to make changes to a single codebase, rather than updating individual WordPress themes.